### PR TITLE
conserve linebreaks in kudos on output

### DIFF
--- a/templates/extend/messages_container.html
+++ b/templates/extend/messages_container.html
@@ -7,7 +7,7 @@
                 <h5 class="card-title">{{ message.title }}</h5>
             {% endif %}
             <h6 class="card-subtitle mb-2 small">{{ message.timestamp }}</h6>
-            <p class="card-text">{{ message.text }}</p>
+            <p class="card-text">{{ message.text|linebreaks }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
When writing longer kudos its nice to use paragraphs.

This pull requests will add paragraphs and line-breaks when displaying kudos.